### PR TITLE
feat: Bot API version 5.2

### DIFF
--- a/examples/payment.rs
+++ b/examples/payment.rs
@@ -1,7 +1,10 @@
 use tbot::{
     markup::{inline_code, markdown_v2},
     prelude::*,
-    types::{parameters::Photo, shipping, LabeledPrice},
+    types::{
+        parameters::{Invoice, Photo, Tip},
+        shipping, LabeledPrice,
+    },
     Bot,
 };
 
@@ -24,22 +27,27 @@ async fn main() {
 
     bot.start(|context, provider_token| async move {
         let call_result = if context.text.value == START_PARAMETER {
-            let price = [LabeledPrice::new(TITLE, 1_00)];
-            let mut invoice = context.send_invoice(
+            let price = [LabeledPrice::new(TITLE, 10_000)];
+            let mut invoice = Invoice::new(
                 TITLE,
                 DESCRIPTION,
                 PAYLOAD,
                 &*provider_token,
-                START_PARAMETER,
                 CURRENCY,
                 price,
             );
             let photo = Photo::new(
                 "https://www.rustacean.net/assets/rustacean-flat-happy.png",
             );
-            invoice = invoice.photo(photo).is_flexible(true);
+            let tip = Tip::with_max(20_00).suggested_tips([19_06, 20_00]);
 
-            invoice.call().await
+            invoice = invoice.photo(photo).is_flexible(true).tip(tip);
+
+            context
+                .send_invoice(invoice)
+                .start_parameter(START_PARAMETER)
+                .call()
+                .await
         } else {
             let error_message = markdown_v2((
                 "Send ",

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -622,7 +622,6 @@ impl Bot {
     }
 
     /// Sends an invoice.
-    #[allow(clippy::too_many_arguments)]
     pub fn send_invoice(
         &self,
         chat_id: impl Into<chat::Id>,

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -25,10 +25,10 @@ use crate::{
         keyboard::inline,
         message,
         parameters::{
-            poll, AllowedUpdates, CallbackAction, ImplicitChatId, Text,
+            poll, AllowedUpdates, CallbackAction, ImplicitChatId, Invoice, Text,
         },
         passport, pre_checkout_query, shipping, user, BotCommand,
-        InlineMessageId, LabeledPrice,
+        InlineMessageId,
     },
 };
 use std::{net::IpAddr, num::NonZeroU32, sync::Arc};
@@ -626,23 +626,9 @@ impl Bot {
     pub fn send_invoice(
         &self,
         chat_id: impl Into<chat::Id>,
-        title: impl Into<String>,
-        description: impl Into<String>,
-        payload: impl Into<String>,
-        provider_token: impl Into<String>,
-        currency: impl Into<String>,
-        prices: impl Into<Vec<LabeledPrice>>,
+        invoice: Invoice,
     ) -> SendInvoice<'_> {
-        SendInvoice::new(
-            &self.inner,
-            chat_id,
-            title,
-            description,
-            payload,
-            provider_token,
-            currency,
-            prices,
-        )
+        SendInvoice::new(&self.inner, chat_id, invoice)
     }
 
     /// Sends a location.

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -630,7 +630,6 @@ impl Bot {
         description: impl Into<String>,
         payload: impl Into<String>,
         provider_token: impl Into<String>,
-        start_parameter: impl Into<String>,
         currency: impl Into<String>,
         prices: impl Into<Vec<LabeledPrice>>,
     ) -> SendInvoice<'_> {
@@ -641,7 +640,6 @@ impl Bot {
             description,
             payload,
             provider_token,
-            start_parameter,
             currency,
             prices,
         )

--- a/src/contexts/inline.rs
+++ b/src/contexts/inline.rs
@@ -19,6 +19,8 @@ common! {
         query: String,
         /// The offset of the result to be returned.
         offset: String,
+        /// The type of chat inline query was sent from.
+        chat_type: Option<inline_query::ChatKind>,
     }
 }
 
@@ -32,6 +34,7 @@ impl Inline {
             location: inline_query.location,
             query: inline_query.query,
             offset: inline_query.offset,
+            chat_type: inline_query.chat_type,
         }
     }
 

--- a/src/contexts/methods/message.rs
+++ b/src/contexts/methods/message.rs
@@ -11,8 +11,8 @@ use crate::{
         },
         keyboard::inline,
         message,
-        parameters::{poll, ImplicitChatId, Text},
-        user, LabeledPrice,
+        parameters::{poll, ImplicitChatId, Invoice, Text},
+        user,
     },
 };
 
@@ -296,46 +296,14 @@ pub trait Message: fields::Message {
 
     /// Sends an invoice to this chat.
     #[allow(clippy::too_many_arguments)]
-    fn send_invoice(
-        &self,
-        title: impl Into<String>,
-        description: impl Into<String>,
-        payload: impl Into<String>,
-        provider_token: impl Into<String>,
-        currency: impl Into<String>,
-        prices: impl Into<Vec<LabeledPrice>>,
-    ) -> SendInvoice<'_> {
-        self.bot().send_invoice(
-            self.chat().id,
-            title,
-            description,
-            payload,
-            provider_token,
-            currency,
-            prices,
-        )
+    fn send_invoice(&self, invoice: Invoice) -> SendInvoice<'_> {
+        self.bot().send_invoice(self.chat().id, invoice)
     }
 
     /// Sends an invoice in reply to this message.
     #[allow(clippy::too_many_arguments)]
-    fn send_invoice_in_reply(
-        &self,
-        title: impl Into<String>,
-        description: impl Into<String>,
-        payload: impl Into<String>,
-        provider_token: impl Into<String>,
-        currency: impl Into<String>,
-        prices: impl Into<Vec<LabeledPrice>>,
-    ) -> SendInvoice<'_> {
-        self.send_invoice(
-            title,
-            description,
-            payload,
-            provider_token,
-            currency,
-            prices,
-        )
-        .in_reply_to(self.message_id())
+    fn send_invoice_in_reply(&self, invoice: Invoice) -> SendInvoice<'_> {
+        self.send_invoice(invoice).in_reply_to(self.message_id())
     }
 
     /// Sends a location to this chat.

--- a/src/contexts/methods/message.rs
+++ b/src/contexts/methods/message.rs
@@ -295,13 +295,11 @@ pub trait Message: fields::Message {
     }
 
     /// Sends an invoice to this chat.
-    #[allow(clippy::too_many_arguments)]
     fn send_invoice(&self, invoice: Invoice) -> SendInvoice<'_> {
         self.bot().send_invoice(self.chat().id, invoice)
     }
 
     /// Sends an invoice in reply to this message.
-    #[allow(clippy::too_many_arguments)]
     fn send_invoice_in_reply(&self, invoice: Invoice) -> SendInvoice<'_> {
         self.send_invoice(invoice).in_reply_to(self.message_id())
     }

--- a/src/contexts/methods/message.rs
+++ b/src/contexts/methods/message.rs
@@ -302,7 +302,6 @@ pub trait Message: fields::Message {
         description: impl Into<String>,
         payload: impl Into<String>,
         provider_token: impl Into<String>,
-        start_parameter: impl Into<String>,
         currency: impl Into<String>,
         prices: impl Into<Vec<LabeledPrice>>,
     ) -> SendInvoice<'_> {
@@ -312,7 +311,6 @@ pub trait Message: fields::Message {
             description,
             payload,
             provider_token,
-            start_parameter,
             currency,
             prices,
         )
@@ -326,7 +324,6 @@ pub trait Message: fields::Message {
         description: impl Into<String>,
         payload: impl Into<String>,
         provider_token: impl Into<String>,
-        start_parameter: impl Into<String>,
         currency: impl Into<String>,
         prices: impl Into<Vec<LabeledPrice>>,
     ) -> SendInvoice<'_> {
@@ -335,7 +332,6 @@ pub trait Message: fields::Message {
             description,
             payload,
             provider_token,
-            start_parameter,
             currency,
             prices,
         )

--- a/src/methods/send_invoice.rs
+++ b/src/methods/send_invoice.rs
@@ -6,47 +6,11 @@ use crate::{
         chat,
         keyboard::inline,
         message::{self, Message},
-        parameters::Photo,
+        parameters::{tip, Photo},
         LabeledPrice,
     },
 };
 use serde::Serialize;
-
-/// Represents tip parameters.
-#[derive(Debug, Clone, Serialize)]
-pub struct Tip {
-    max_tip_amount: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    suggested_tip_amounts: Option<Vec<u32>>,
-}
-
-impl Tip {
-    pub fn with_max(max_tip: u32) -> Self {
-        Self {
-            max_tip_amount: max_tip,
-            suggested_tip_amounts: None,
-        }
-    }
-
-    /// Configures suggested tip amounts for the invoice.
-    /// At most 4 suggestions can be specified.
-    /// Reflects the `suggested_tip_amounts` parameter.
-    ///
-    /// # Panics
-    ///
-    /// Panics if there are more than 4 elements.
-    pub fn suggested_tips(mut self, suggested: impl Into<Vec<u32>>) -> Self {
-        let mut suggested = suggested.into();
-        assert!(
-            (1..=4).contains(&suggested.len()),
-            "[tbot] Received invalid `suggested` in \
-             `Tip::suggested_tips` must have at most 4 elements.",
-        );
-        suggested.sort();
-        self.suggested_tip_amounts = Some(suggested);
-        self
-    }
-}
 
 /// Sends an invoice.
 ///
@@ -92,8 +56,8 @@ pub struct SendInvoice<'a> {
     allow_sending_without_reply: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_markup: Option<inline::Keyboard>,
-    #[serde(flatten, skip_serializing_if = "Option::is_none")]
-    tip: Option<Tip>,
+    #[serde(flatten)]
+    tip: Option<tip::Tip>,
 }
 
 impl<'a> SendInvoice<'a> {
@@ -246,8 +210,9 @@ impl<'a> SendInvoice<'a> {
     }
 
     /// Configures tip for the invoice.
-    /// Reflects the `tip` field (`max_tip_amount`, `suggested_tip_amounts`).
-    pub fn tip(mut self, tip: Tip) -> Self {
+    /// Reflects the `tip` parameter.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn tip(mut self, tip: tip::Tip) -> Self {
         self.tip = Some(tip);
         self
     }

--- a/src/methods/send_invoice.rs
+++ b/src/methods/send_invoice.rs
@@ -54,6 +54,16 @@ impl<'a> SendInvoice<'a> {
         }
     }
 
+    /// Configures unique deep-linking parameter for "Pay button" to redirect.
+    /// Reflects the `start_parameter` parameter.
+    pub fn start_parameter(
+        mut self,
+        start_parameter: impl Into<String>,
+    ) -> Self {
+        self.start_parameter = Some(start_parameter.into());
+        self
+    }
+
     /// Configures whether the message is sent silently.
     /// Reflects the `disable_notification` parameter.
     pub const fn is_notification_disabled(mut self, is_disabled: bool) -> Self {
@@ -81,16 +91,6 @@ impl<'a> SendInvoice<'a> {
     #[allow(clippy::missing_const_for_fn)]
     pub fn reply_markup(mut self, markup: inline::Keyboard) -> Self {
         self.reply_markup = Some(markup);
-        self
-    }
-
-    /// Configures unique deep-linking parameter for "Pay button" to redirect.
-    /// Reflects the `start_parameter` parameter.
-    pub fn start_parameter(
-        mut self,
-        start_parameter: impl Into<String>,
-    ) -> Self {
-        self.start_parameter = Some(start_parameter.into());
         self
     }
 }

--- a/src/methods/send_invoice.rs
+++ b/src/methods/send_invoice.rs
@@ -6,8 +6,7 @@ use crate::{
         chat,
         keyboard::inline,
         message::{self, Message},
-        parameters::{tip, Photo},
-        LabeledPrice,
+        parameters::Invoice,
     },
 };
 use serde::Serialize;
@@ -23,32 +22,8 @@ pub struct SendInvoice<'a> {
     #[serde(skip)]
     bot: &'a InnerBot,
     chat_id: chat::Id,
-    title: String,
-    description: String,
-    payload: String,
-    provider_token: String,
-    currency: String,
-    prices: Vec<LabeledPrice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     start_parameter: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    provider_data: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", flatten)]
-    photo: Option<Photo>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    need_name: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    need_phone_number: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    need_email: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    need_shipping_address: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    send_phone_number_to_provider: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    send_email_to_provider: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    is_flexible: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     disable_notification: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +32,7 @@ pub struct SendInvoice<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     reply_markup: Option<inline::Keyboard>,
     #[serde(flatten)]
-    tip: Option<tip::Tip>,
+    invoice: Invoice,
 }
 
 impl<'a> SendInvoice<'a> {
@@ -65,108 +40,18 @@ impl<'a> SendInvoice<'a> {
     pub(crate) fn new(
         bot: &'a InnerBot,
         chat_id: impl Into<chat::Id>,
-        title: impl Into<String>,
-        description: impl Into<String>,
-        payload: impl Into<String>,
-        provider_token: impl Into<String>,
-        currency: impl Into<String>,
-        prices: impl Into<Vec<LabeledPrice>>,
+        invoice: Invoice,
     ) -> Self {
         Self {
             bot,
             chat_id: chat_id.into(),
-            title: title.into(),
-            description: description.into(),
-            payload: payload.into(),
-            provider_token: provider_token.into(),
-            currency: currency.into(),
-            prices: prices.into(),
+            invoice,
             start_parameter: None,
-            provider_data: None,
-            photo: None,
-            need_name: None,
-            need_phone_number: None,
-            need_email: None,
-            need_shipping_address: None,
-            send_phone_number_to_provider: None,
-            send_email_to_provider: None,
-            is_flexible: None,
             disable_notification: None,
             reply_to_message_id: None,
             allow_sending_without_reply: false,
             reply_markup: None,
-            tip: None,
         }
-    }
-
-    /// Configures data for your payment provider.
-    /// Reflects the `provider_data` parameter.
-    pub fn provider_data(mut self, provider_data: impl Into<String>) -> Self {
-        self.provider_data = Some(provider_data.into());
-        self
-    }
-
-    /// Configures a photo for the invoice.
-    /// Reflects the `photo_url`, `photo_width` and `photo_height` parameters.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn photo(mut self, photo: Photo) -> Self {
-        self.photo = Some(photo);
-        self
-    }
-
-    /// Configures whether the user must specify their name.
-    /// Reflects the `need_name` parameters.
-    pub const fn is_name_needed(mut self, is_needed: bool) -> Self {
-        self.need_name = Some(is_needed);
-        self
-    }
-
-    /// Configures whether the user must specify their phone number.
-    /// Reflects the `need_phone_number` parameter.
-    pub const fn is_phone_number_needed(mut self, is_needed: bool) -> Self {
-        self.need_phone_number = Some(is_needed);
-        self
-    }
-
-    /// Configures whether the user must specify their email.
-    /// Reflects the `need_email` parameter.
-    pub const fn is_email_needed(mut self, is_needed: bool) -> Self {
-        self.need_email = Some(is_needed);
-        self
-    }
-
-    /// Configures whether the user must specify their shipping address.
-    /// Reflects the `need_shipping_address` parameter.
-    pub const fn is_shipping_address_needed(mut self, is_needed: bool) -> Self {
-        self.need_shipping_address = Some(is_needed);
-        self
-    }
-
-    /// Configures whether the user's phone must be sent to your payment
-    /// provider. Reflects the `send_phone_number_to_provider` parameter.
-    pub const fn should_send_phone_number_to_provider(
-        mut self,
-        must_send: bool,
-    ) -> Self {
-        self.send_phone_number_to_provider = Some(must_send);
-        self
-    }
-
-    /// Configures whether the user's email must be sent to your payment
-    /// provider. Reflects the `send_email_to_provider` parameter.
-    pub const fn should_send_email_to_provider(
-        mut self,
-        must_send: bool,
-    ) -> Self {
-        self.send_email_to_provider = Some(must_send);
-        self
-    }
-
-    /// Configures whether the final price depends on the shipping method.
-    /// Reflects the `is_flexible` parameter.
-    pub const fn is_flexible(mut self, is_flexible: bool) -> Self {
-        self.is_flexible = Some(is_flexible);
-        self
     }
 
     /// Configures whether the message is sent silently.
@@ -206,14 +91,6 @@ impl<'a> SendInvoice<'a> {
         start_parameter: impl Into<String>,
     ) -> Self {
         self.start_parameter = Some(start_parameter.into());
-        self
-    }
-
-    /// Configures tip for the invoice.
-    /// Reflects the `tip` parameter.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn tip(mut self, tip: tip::Tip) -> Self {
-        self.tip = Some(tip);
         self
     }
 }

--- a/src/methods/send_invoice.rs
+++ b/src/methods/send_invoice.rs
@@ -36,7 +36,6 @@ pub struct SendInvoice<'a> {
 }
 
 impl<'a> SendInvoice<'a> {
-    #[allow(clippy::too_many_arguments)] // I know, brother
     pub(crate) fn new(
         bot: &'a InnerBot,
         chat_id: impl Into<chat::Id>,

--- a/src/types/chat/action.rs
+++ b/src/types/chat/action.rs
@@ -15,10 +15,10 @@ pub enum Action {
     RecordVideo,
     /// About to send a video.
     UploadVideo,
-    /// About to send a generated audio.
-    RecordAudio,
-    /// About to send an audio.
-    UploadAudio,
+    /// About to send a generated voice-audio.
+    RecordVoice,
+    /// About to send a voice-audio.
+    UploadVoice,
     /// About to send a document.
     UploadDocument,
     /// About to send a location.

--- a/src/types/chat/action.rs
+++ b/src/types/chat/action.rs
@@ -15,9 +15,9 @@ pub enum Action {
     RecordVideo,
     /// About to send a video.
     UploadVideo,
-    /// About to send a generated voice-audio.
+    /// About to send a generated voice message.
     RecordVoice,
-    /// About to send a voice-audio.
+    /// About to send a voice message.
     UploadVoice,
     /// About to send a document.
     UploadDocument,

--- a/src/types/inline_query.rs
+++ b/src/types/inline_query.rs
@@ -1,8 +1,8 @@
 //! Types related to inline queries.
 
 use crate::types::{Location, User};
-use serde::Deserialize;
 use is_macro::Is;
+use serde::Deserialize;
 
 mod id;
 pub mod result;

--- a/src/types/inline_query.rs
+++ b/src/types/inline_query.rs
@@ -2,11 +2,28 @@
 
 use crate::types::{Location, User};
 use serde::Deserialize;
+use is_macro::Is;
 
 mod id;
 pub mod result;
 
 pub use {id::Id, result::Result};
+
+/// Represents the kind of a chat.
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy, Is, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChatKind {
+    /// The chat is private.
+    Sender,
+    /// The chat is private.
+    Private,
+    /// The chat is a channel.
+    Channel,
+    /// The chat is a group.
+    Group,
+    /// The chat is a supergroup.
+    Supergroup,
+}
 
 /// Represents an [`InlineQuery`].
 ///
@@ -24,4 +41,6 @@ pub struct InlineQuery {
     pub query: String,
     /// The offset of the result to be returned.
     pub offset: String,
+    /// The type of chat inline query was sent from.
+    pub chat_type: Option<ChatKind>,
 }

--- a/src/types/input_message_content.rs
+++ b/src/types/input_message_content.rs
@@ -4,13 +4,17 @@ use is_macro::Is;
 use serde::Serialize;
 
 mod contact;
+mod invoice;
 mod location;
 mod text;
 mod venue;
 
-pub use {contact::Contact, location::Location, text::Text, venue::Venue};
+pub use {
+    contact::Contact, invoice::Invoice, location::Location, text::Text,
+    venue::Venue,
+};
 
-/// Represents [`InputMessageContext`][docs].
+/// Represents [`InputMessageContent`][docs].
 ///
 /// [docs]: https://core.telegram.org/bots/api#inputmessagecontent
 #[derive(Debug, PartialEq, Clone, Serialize, Is)]
@@ -25,6 +29,8 @@ pub enum InputMessageContent {
     Venue(Venue),
     /// A contact.
     Contact(Contact),
+    /// An invoice.
+    Invoice(Invoice),
 }
 
 impl From<Text> for InputMessageContent {
@@ -52,5 +58,12 @@ impl From<Contact> for InputMessageContent {
     #[must_use]
     fn from(contact: Contact) -> Self {
         Self::Contact(contact)
+    }
+}
+
+impl From<Invoice> for InputMessageContent {
+    #[must_use]
+    fn from(invoice: Invoice) -> Self {
+        Self::Invoice(invoice)
     }
 }

--- a/src/types/input_message_content/invoice.rs
+++ b/src/types/input_message_content/invoice.rs
@@ -6,7 +6,15 @@ use serde::Serialize;
 ///
 /// [docs]: https://core.telegram.org/bots/api#inputinvoicemessagecontent
 #[derive(Debug, Serialize, Eq, PartialEq, Clone, Hash)]
+#[must_use]
 pub struct Invoice {
     #[serde(flatten)]
     invoice: InvoiceParams,
+}
+
+impl Invoice {
+    /// Construct an `Invoice`.
+    pub const fn new(invoice: InvoiceParams) -> Self {
+        Self { invoice }
+    }
 }

--- a/src/types/input_message_content/invoice.rs
+++ b/src/types/input_message_content/invoice.rs
@@ -1,0 +1,12 @@
+use crate::types::parameters::Invoice as InvoiceParams;
+
+use serde::Serialize;
+
+/// Represents an [`InputInvoiceMessageContent`][docs].
+///
+/// [docs]: https://core.telegram.org/bots/api#inputinvoicemessagecontent
+#[derive(Debug, Serialize, Eq, PartialEq, Clone, Hash)]
+pub struct Invoice {
+    #[serde(flatten)]
+    invoice: InvoiceParams,
+}

--- a/src/types/invoice.rs
+++ b/src/types/invoice.rs
@@ -11,7 +11,7 @@ pub struct Invoice {
     /// The description of the invoice.
     pub description: String,
     /// The start parameter of the invoice.
-    pub start_parameter: String,
+    pub start_parameter: Option<String>,
     /// The currency of the invoice.
     pub currency: String,
     /// The total amount of the invoice.

--- a/src/types/parameters.rs
+++ b/src/types/parameters.rs
@@ -3,16 +3,19 @@
 mod allowed_updates;
 mod callback_action;
 mod chat_id;
+mod invoice;
 mod photo;
 pub mod poll;
 mod text;
-pub mod tip;
+mod tip;
 
 pub(crate) use text::ParseMode;
 pub use {
     allowed_updates::AllowedUpdates,
     callback_action::CallbackAction,
     chat_id::{ChatId, ImplicitChatId},
+    invoice::Invoice,
     photo::Photo,
     text::Text,
+    tip::Tip,
 };

--- a/src/types/parameters.rs
+++ b/src/types/parameters.rs
@@ -6,6 +6,7 @@ mod chat_id;
 mod photo;
 pub mod poll;
 mod text;
+pub mod tip;
 
 pub(crate) use text::ParseMode;
 pub use {

--- a/src/types/parameters/invoice.rs
+++ b/src/types/parameters/invoice.rs
@@ -1,0 +1,148 @@
+//! Types related to invoice parameters.
+
+use crate::types::{
+    parameters::{Photo, Tip},
+    LabeledPrice,
+};
+use serde::Serialize;
+
+/// Miscellaneous parameters for Invoice methods and types.
+#[derive(Debug, Serialize, Eq, PartialEq, Clone, Hash)]
+#[must_use]
+pub struct Invoice {
+    title: String,
+    description: String,
+    payload: String,
+    provider_token: String,
+    currency: String,
+    prices: Vec<LabeledPrice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provider_data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    photo: Option<Photo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    need_name: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    need_phone_number: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    need_email: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    need_shipping_address: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    send_phone_number_to_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    send_email_to_provider: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    is_flexible: Option<bool>,
+    #[serde(flatten)]
+    tip: Option<Tip>,
+}
+
+impl Invoice {
+    /// Constructs an `Invoice`.
+    pub fn new(
+        title: impl Into<String>,
+        description: impl Into<String>,
+        payload: impl Into<String>,
+        provider_token: impl Into<String>,
+        currency: impl Into<String>,
+        prices: impl Into<Vec<LabeledPrice>>,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            description: description.into(),
+            payload: payload.into(),
+            provider_token: provider_token.into(),
+            currency: currency.into(),
+            prices: prices.into(),
+            provider_data: None,
+            photo: None,
+            need_name: None,
+            need_phone_number: None,
+            need_email: None,
+            need_shipping_address: None,
+            send_phone_number_to_provider: None,
+            send_email_to_provider: None,
+            is_flexible: None,
+            tip: None,
+        }
+    }
+
+    /// Configures data for your payment provider.
+    /// Reflects the `provider_data` parameter.
+    pub fn provider_data(mut self, provider_data: impl Into<String>) -> Self {
+        self.provider_data = Some(provider_data.into());
+        self
+    }
+
+    /// Configures a photo for the invoice.
+    /// Reflects the `photo_url`, `photo_width` and `photo_height` parameters.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn photo(mut self, photo: Photo) -> Self {
+        self.photo = Some(photo);
+        self
+    }
+
+    /// Configures whether the user must specify their name.
+    /// Reflects the `need_name` parameters.
+    pub const fn is_name_needed(mut self, is_needed: bool) -> Self {
+        self.need_name = Some(is_needed);
+        self
+    }
+
+    /// Configures whether the user must specify their phone number.
+    /// Reflects the `need_phone_number` parameter.
+    pub const fn is_phone_number_needed(mut self, is_needed: bool) -> Self {
+        self.need_phone_number = Some(is_needed);
+        self
+    }
+
+    /// Configures whether the user must specify their email.
+    /// Reflects the `need_email` parameter.
+    pub const fn is_email_needed(mut self, is_needed: bool) -> Self {
+        self.need_email = Some(is_needed);
+        self
+    }
+
+    /// Configures whether the user must specify their shipping address.
+    /// Reflects the `need_shipping_address` parameter.
+    pub const fn is_shipping_address_needed(mut self, is_needed: bool) -> Self {
+        self.need_shipping_address = Some(is_needed);
+        self
+    }
+
+    /// Configures whether the user's phone must be sent to your payment
+    /// provider. Reflects the `send_phone_number_to_provider` parameter.
+    pub const fn should_send_phone_number_to_provider(
+        mut self,
+        must_send: bool,
+    ) -> Self {
+        self.send_phone_number_to_provider = Some(must_send);
+        self
+    }
+
+    /// Configures whether the user's email must be sent to your payment
+    /// provider. Reflects the `send_email_to_provider` parameter.
+    pub const fn should_send_email_to_provider(
+        mut self,
+        must_send: bool,
+    ) -> Self {
+        self.send_email_to_provider = Some(must_send);
+        self
+    }
+
+    /// Configures whether the final price depends on the shipping method.
+    /// Reflects the `is_flexible` parameter.
+    pub const fn is_flexible(mut self, is_flexible: bool) -> Self {
+        self.is_flexible = Some(is_flexible);
+        self
+    }
+
+    /// Configures tip for the invoice.
+    /// Reflects the `tip` parameter.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn tip(mut self, tip: Tip) -> Self {
+        self.tip = Some(tip);
+        self
+    }
+}

--- a/src/types/parameters/tip.rs
+++ b/src/types/parameters/tip.rs
@@ -11,7 +11,8 @@ pub struct Tip {
 }
 
 impl Tip {
-    /// Initialize a `Tip` with a given max tip amount.
+    /// Constructs a `Tip` with the given max tip amount.
+    /// Reflects the `max_tip_amount` parameter.
     #[must_use]
     pub const fn with_max(max_tip: u32) -> Self {
         Self {
@@ -26,7 +27,10 @@ impl Tip {
     ///
     /// # Panics
     ///
-    /// Panics if there are more than 4 elements.
+    /// Panics if:
+    /// - there are more than 4 elements.
+    /// - the value contains duplicates.
+    /// - the biggest element is exceeding `max_tip_amount`.
     pub fn suggested_tips(mut self, suggested: impl Into<Vec<u32>>) -> Self {
         let mut suggested = suggested.into();
         assert!(
@@ -43,11 +47,12 @@ impl Tip {
              `Tip::suggested_tips`: value most consist of unique elements.",
         );
         assert!(
-            suggested[3] <= self.max_tip_amount,
+            // this is a safe unwrap, since we've checked the length earlier
+            *suggested.last().unwrap() < self.max_tip_amount,
             "[tbot] Received invalid `suggested` in \
              `Tip::suggested_tips`: the maximum value {} \
              is exceeding `max_tip_amount` which was set to {}.",
-            suggested[3],
+            suggested.last().unwrap(),
             self.max_tip_amount,
         );
         self.suggested_tip_amounts = Some(suggested);

--- a/src/types/parameters/tip.rs
+++ b/src/types/parameters/tip.rs
@@ -1,0 +1,56 @@
+//! Types related to tips in invoices.
+
+use serde::Serialize;
+
+/// Represents tip parameters.
+#[derive(Debug, Clone, Serialize, Eq, PartialEq, Hash)]
+pub struct Tip {
+    max_tip_amount: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    suggested_tip_amounts: Option<Vec<u32>>,
+}
+
+impl Tip {
+    /// Initialize a `Tip` with a given max tip amount.
+    #[must_use]
+    pub const fn with_max(max_tip: u32) -> Self {
+        Self {
+            max_tip_amount: max_tip,
+            suggested_tip_amounts: None,
+        }
+    }
+
+    /// Configures suggested tip amounts for the invoice.
+    /// At most 4 suggestions can be specified.
+    /// Reflects the `suggested_tip_amounts` parameter.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there are more than 4 elements.
+    pub fn suggested_tips(mut self, suggested: impl Into<Vec<u32>>) -> Self {
+        let mut suggested = suggested.into();
+        assert!(
+            (1..=4).contains(&suggested.len()),
+            "[tbot] Received invalid `suggested` in \
+             `Tip::suggested_tips`: must contain from 1 to 4 elements, \
+             contains {} elements instead.",
+            suggested.len(),
+        );
+        suggested.sort_unstable();
+        assert!(
+            suggested.windows(2).all(|win| win[0] != win[1]),
+            "[tbot] Received invalid `suggested` in \
+             `Tip::suggested_tips`: value most consist of unique elements.",
+        );
+        assert!(
+            suggested[3] <= self.max_tip_amount,
+            "[tbot] Received invalid `suggested` in \
+             `Tip::suggested_tips`: the maximum value {} \
+             is exceeding `max_tip_amount` which was set to {}.",
+            suggested[3],
+            self.max_tip_amount,
+        );
+        self.suggested_tip_amounts = Some(suggested);
+        self
+    }
+}

--- a/src/types/parameters/tip.rs
+++ b/src/types/parameters/tip.rs
@@ -23,12 +23,13 @@ impl Tip {
 
     /// Configures suggested tip amounts for the invoice.
     /// At most 4 suggestions can be specified.
+    /// This method automatically sorts the data given.
     /// Reflects the `suggested_tip_amounts` parameter.
     ///
     /// # Panics
     ///
     /// Panics if:
-    /// - there are more than 4 elements.
+    /// - the value consists of more than 4 elements.
     /// - the value contains duplicates.
     /// - the biggest element is exceeding `max_tip_amount`.
     pub fn suggested_tips(mut self, suggested: impl Into<Vec<u32>>) -> Self {

--- a/src/types/parameters/tip.rs
+++ b/src/types/parameters/tip.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 
 /// Represents tip parameters.
 #[derive(Debug, Clone, Serialize, Eq, PartialEq, Hash)]
+#[must_use]
 pub struct Tip {
     max_tip_amount: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13,7 +14,6 @@ pub struct Tip {
 impl Tip {
     /// Constructs a `Tip` with the given max tip amount.
     /// Reflects the `max_tip_amount` parameter.
-    #[must_use]
     pub const fn with_max(max_tip: u32) -> Self {
         Self {
             max_tip_amount: max_tip,


### PR DESCRIPTION
- New type: `InputInvoiceMessageContent`
- New fields: `SendInvoice::{max_tip_amount, suggested_tip_amounts}`
- Changed field: `SendInvoice::start_parameter` became optional
- Chat actions renamed: `Action::{UploadAudio, RecordAudio}` -> `Action::{UploadVoice, RecordVoice}`
- New field `InlineQuery::chat_type`